### PR TITLE
Migrate slideshows to custom post type

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ _Wordpress Plugin_
 
 **Requires at least:** 3.5
 
-**Tested up to:** 4.1.1
+**Tested up to:** 4.2
 
 **Stable tag:** 2.2.1
 

--- a/bu-slideshow.php
+++ b/bu-slideshow.php
@@ -758,7 +758,7 @@ class BU_Slideshow {
 	 */
 	static public function get_slideshows() {
 		$slideshows = array();
-		$slideshow_posts = get_posts( array( 'post_type' => 'bu_slideshow' ) );
+		$slideshow_posts = get_posts( array( 'post_type' => 'bu_slideshow', 'posts_per_page' => -1 ) );
 
 		foreach ($slideshow_posts as $show) {
 			$slideshows[ $show->ID ] = self::get_slideshow( $show->ID );

--- a/bu-slideshow.php
+++ b/bu-slideshow.php
@@ -77,6 +77,7 @@ class BU_Slideshow {
 		self::$wp_version = get_bloginfo('version');
 		self::$upload_error = __(self::$upload_error, BU_SSHOW_LOCAL);
 		
+		add_action('init', array(__CLASS__, 'register_cpt'), 6);
 		add_action('init', array(__CLASS__, 'custom_thumb_size'));
 		add_action('init', array(__CLASS__, 'add_post_support'),99);
 		add_action('admin_menu', array(__CLASS__, 'admin_menu'));
@@ -102,6 +103,16 @@ class BU_Slideshow {
 		
 	}
 	
+	static public function register_cpt(){
+		$args = array(
+				'public'			=> false,
+				'capability_type'	=> 'post',
+				'supports'			=> false,
+			);
+
+		register_post_type( 'bu_slideshow', $args );
+	}
+
 	static public function add_post_support() {
 		$post_types = apply_filters('bu_slideshow_supported_post_types', self::$supported_post_types);
 		
@@ -726,7 +737,7 @@ class BU_Slideshow {
 	 */
 	static public function get_slideshow($id) {
 		$all_slideshows = self::get_slideshows();
-		
+
 		return array_key_exists($id, $all_slideshows) ? $all_slideshows[$id] : false;
 	}
 	
@@ -736,10 +747,12 @@ class BU_Slideshow {
 	 * @return array
 	 */
 	static public function get_slideshows() {
+
 		$all_slideshows = get_option(self::$meta_key, array());
 		if (!is_array($all_slideshows)) {
 			$all_slideshows = array();
 		}
+
 		return $all_slideshows;
 	}
 	

--- a/bu-slideshow.php
+++ b/bu-slideshow.php
@@ -758,7 +758,13 @@ class BU_Slideshow {
 	 */
 	static public function get_slideshows() {
 		$slideshows = array();
-		$slideshow_posts = get_posts( array( 'post_type' => 'bu_slideshow', 'posts_per_page' => -1 ) );
+		$slideshow_posts = get_posts( array( 
+			'post_type' => 'bu_slideshow', 
+			'posts_per_page' => -1, 
+			'orderby' => 'title', 
+			'order' => 'asc' 
+			) 
+		);
 
 		foreach ($slideshow_posts as $show) {
 			$slideshows[ $show->ID ] = self::get_slideshow( $show->ID );

--- a/bu-slideshow.php
+++ b/bu-slideshow.php
@@ -7,7 +7,8 @@
  Author: Boston University (IS&T)
  Author URI: http://www.bu.edu/tech/
  * 
- * Currently supports WP 3.5.X.
+ * Currently supports WP 3.5+
+ * Tested to WP 4.2
  * 
 */
 

--- a/bu-slideshow.php
+++ b/bu-slideshow.php
@@ -107,10 +107,20 @@ class BU_Slideshow {
 	
 	static public function register_cpt(){
 		$args = array(
-			  'public'           => false,
-			  'capability_type'  => 'post',
-			  'supports'         => false,
-			);
+			'labels'             => array(),
+			'public'             => false,
+			'publicly_queryable' => false,
+			'show_ui'            => false,
+			'show_in_menu'       => false,
+			'query_var'          => false,
+			'rewrite'            => false,
+			'capability_type'    => 'post',
+			'has_archive'        => false,
+			'hierarchical'       => false,
+			'menu_position'      => null,
+			'supports'           => false,
+			'can_export'         => true,
+		);
 
 		register_post_type( 'bu_slideshow', $args );
 	}

--- a/bu-slideshow.php
+++ b/bu-slideshow.php
@@ -107,9 +107,9 @@ class BU_Slideshow {
 	
 	static public function register_cpt(){
 		$args = array(
-				'public'			=> false,
-				'capability_type'	=> 'post',
-				'supports'			=> false,
+				'public'           => false,
+				'capability_type'  => 'post',
+				'supports'         => false,
 			);
 
 		register_post_type( 'bu_slideshow', $args );
@@ -724,7 +724,7 @@ class BU_Slideshow {
 	
 	/**
 	* Determine if slideshow ID was created before v3.2
-	* If it is, fetch the new post ID.
+	* If it was, fetch the new post ID.
 	* 
 	* @param int $id
 	* @return int

--- a/bu-slideshow.php
+++ b/bu-slideshow.php
@@ -107,9 +107,9 @@ class BU_Slideshow {
 	
 	static public function register_cpt(){
 		$args = array(
-				'public'           => false,
-				'capability_type'  => 'post',
-				'supports'         => false,
+			  'public'           => false,
+			  'capability_type'  => 'post',
+			  'supports'         => false,
 			);
 
 		register_post_type( 'bu_slideshow', $args );
@@ -716,7 +716,6 @@ class BU_Slideshow {
 	 * @return boolean
 	 */
 	static public function slideshow_exists($id) {
-
 		$id = self::slideshow_maybe_translate_id( $id );
 
 		return ( 'object' === gettype( get_post_meta( $id, '_bu_slideshow', TRUE ) ) );
@@ -730,7 +729,6 @@ class BU_Slideshow {
 	* @return int
 	*/
 	static public function slideshow_maybe_translate_id($id){
-
 		$old_slideshow_ids = get_option( 'bu_slideshow_id_map', array() );
 
 		if( array_key_exists( $id, $old_slideshow_ids ) ){
@@ -747,9 +745,7 @@ class BU_Slideshow {
 	 * @return bool|array
 	 */
 	static public function get_slideshow($id) {
-
 		$id = self::slideshow_maybe_translate_id( $id );
-
 		$slideshow = get_post_meta( $id, '_bu_slideshow', TRUE );
 
 		return ( 'object' === gettype( $slideshow ) ) ? $slideshow : FALSE;
@@ -761,7 +757,6 @@ class BU_Slideshow {
 	 * @return array
 	 */
 	static public function get_slideshows() {
-
 		$slideshows = array();
 		$slideshow_posts = get_posts( array( 'post_type' => 'bu_slideshow' ) );
 

--- a/class-bu-slide.php
+++ b/class-bu-slide.php
@@ -17,6 +17,7 @@ class BU_Slide {
 		'position' => 'caption-bottom-right'
 	);
 	public $order = 0;
+	public $template_id = '';
 	public $view;
 	public $additional_styles = '';
 	
@@ -38,6 +39,14 @@ class BU_Slide {
 	 */
 	public function set_order($order) {
 		$this->order = intval($order);
+	}
+
+	/**
+	 * Set the template of this slide
+	 * @param string $template_id
+	 */
+	public function set_template($template_id) {
+		$this->template_id = $template_id;
 	}
 	
 	/**
@@ -63,7 +72,7 @@ class BU_Slide {
 			case 'admin':
 
 				$img_thumb = '';
-				$caption_positions = apply_filters("bu_slideshow_caption_positions", BU_Slideshow::$caption_positions);
+				$caption_positions = apply_filters('bu_slideshow_caption_positions', BU_Slideshow::$caption_positions);
 				$this->caption = stripslashes_deep($this->caption);
 
 				if ($this->image_id) {
@@ -91,13 +100,21 @@ class BU_Slide {
 				$haslink = false;
 
 				$this->caption = stripslashes_deep($this->caption);
+				$this->image_html = $this->get_image_html();
+				$this->caption['html'] = $this->get_caption_html();
+
+				if( !empty( $this->template_id ) ){
+					$templates = apply_filters('bu_slideshow_slide_templates', BU_Slideshow::$slide_templates);
+					$this->template_options = $templates[ $this->template_id ];
+				} else {
+					$this->template_options = array();
+				}
 
 				$html = sprintf('<li id="%s" class="slide %s">', $slide_id, $additional_styles);
 				$html .= sprintf('<div class="bu-slide-container %s">', $caption_class);
 				
-				$html .= $this->get_image_html();
-				
-				$html .= $this->get_caption_html();
+				$slide_inner = $this->image_html . $this->caption['html'];
+				$html .= apply_filters( 'bu_slideshow_slide_html', $slide_inner, $this );
 				
 				$html .= '</div></li>';
 

--- a/class-bu-slideshow.php
+++ b/class-bu-slideshow.php
@@ -101,7 +101,7 @@ class BU_Slideshow_Instance {
 	 * 
 	 * @return int
 	 */
-	protected function create_post(){
+	public function create_post(){
 		// Create post object
 		$post = array(
 		  'post_title'    => $this->name,

--- a/class-bu-slideshow.php
+++ b/class-bu-slideshow.php
@@ -10,7 +10,7 @@ class BU_Slideshow_Instance {
 	
 	public $view;
 	public $name = '';
-	public $id = 1;
+	public $id = 0;
 	public $height = 0;
 	public $slides = array();
 	
@@ -27,8 +27,6 @@ class BU_Slideshow_Instance {
 		}
 		
 		$this->name = __('Untitled Slideshow', BU_SSHOW_LOCAL);
-		$id = BU_Slideshow::get_new_id();
-		$this->id = $id;
 		
 		if (isset($args['view'])) {
 			$this->set_view($args['view']);

--- a/class-bu-slideshow.php
+++ b/class-bu-slideshow.php
@@ -104,10 +104,10 @@ class BU_Slideshow_Instance {
 	protected function create_post(){
 		// Create post object
 		$post = array(
-			'post_title'	=> $this->name,
-			'post_content'	=> '',
-			'post_status'	=> 'publish',
-			'post_type'		=> 'bu_slideshow',
+		  'post_title'    => $this->name,
+		  'post_content'  => '',
+		  'post_status'   => 'publish',
+		  'post_type'     => 'bu_slideshow',
 		);
 
 		$result = $postID = wp_insert_post( $post );

--- a/interface/slideshow-selector.php
+++ b/interface/slideshow-selector.php
@@ -8,8 +8,8 @@
 				<select name="bu_slideshow_selected" id="bu_slideshow_selected">
 					<option value="0"<?php if (!$args['show_id']) echo ' selected="selected"'; ?>></option>
 					<?php foreach ($all_slideshows as $show) {
-						$sel = intval($args['show_id']) === $show->id ? ' selected="selected"' : '';
-						printf('<option value="%d"%s>%s</option>', esc_attr($show->id), $sel, esc_html($show->name));
+						$id = BU_Slideshow::slideshow_maybe_translate_id( $show->id );
+						printf('<option value="%d"%s>%s</option>', esc_attr($id), selected( $show->id, $args['show_id'] ), esc_html($show->name));
 					} ?>
 				</select>
 			</p>

--- a/interface/slideshow-selector.php
+++ b/interface/slideshow-selector.php
@@ -7,9 +7,8 @@
 				<label for="bu_slideshow_selected"><?php _e('Select Slideshow:', BU_SSHOW_LOCAL); ?></label><br/>
 				<select name="bu_slideshow_selected" id="bu_slideshow_selected">
 					<option value="0"<?php if (!$args['show_id']) echo ' selected="selected"'; ?>>Select...</option>
-					<?php foreach ($all_slideshows as $show) {
-						$id = BU_Slideshow::slideshow_maybe_translate_id( $show->id );
-						printf('<option value="%d"%s>%s</option>', esc_attr($id), selected( $show->id, $args['show_id'] ), esc_html($show->name));
+					<?php foreach ($all_slideshows as $id => $show) {
+						printf('<option value="%d"%s>%s</option>', esc_attr($id), selected( $id, $args['show_id'] ), esc_html($show->name));
 					} ?>
 				</select>
 			</p>

--- a/interface/slideshow-selector.php
+++ b/interface/slideshow-selector.php
@@ -6,7 +6,7 @@
 			<p>
 				<label for="bu_slideshow_selected"><?php _e('Select Slideshow:', BU_SSHOW_LOCAL); ?></label><br/>
 				<select name="bu_slideshow_selected" id="bu_slideshow_selected">
-					<option value="0"<?php if (!$args['show_id']) echo ' selected="selected"'; ?>></option>
+					<option value="0"<?php if (!$args['show_id']) echo ' selected="selected"'; ?>>Select...</option>
 					<?php foreach ($all_slideshows as $show) {
 						$id = BU_Slideshow::slideshow_maybe_translate_id( $show->id );
 						printf('<option value="%d"%s>%s</option>', esc_attr($id), selected( $show->id, $args['show_id'] ), esc_html($show->name));

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: awbauer, clrux, mgburns, gannondigital
 Tags: slideshow, images, boston university, bu
 Requires at least: 3.5
-Tested up to: 4.1.1
+Tested up to: 4.2
 Stable tag: 2.2.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/slideshow-upgrade.php
+++ b/slideshow-upgrade.php
@@ -58,7 +58,7 @@ function bu_slideshow_migrate_shows() {
 		    $has_errors = TRUE;
 		} else {
 			if( false === add_post_meta( $postID, '_bu_slideshow', $show, true ) ){
-				error_log( sprintf( '[%s] Error adding posst meta: ID %d Object: %s',
+				error_log( sprintf( '[%s] Error adding post meta: ID %d Object: %s',
 					__FUNCTION__, $postID, var_export( $show, TRUE ) ) );
 				$has_errors = TRUE;
 			}

--- a/slideshow-upgrade.php
+++ b/slideshow-upgrade.php
@@ -8,11 +8,11 @@ add_action('init', 'bu_slideshow_upgrade', 99);
  */
 function bu_slideshow_upgrade() {
 	$current_version = get_option('bu_slideshow_version');
+	$run_all = ( FALSE === $current_version && version_compare('2.3', BU_SLIDESHOW_VERSION, '<=') );
 
-	if ( ( empty($current_version) && version_compare('2.3', BU_SLIDESHOW_VERSION, '<=') ) 
-		|| -1 === version_compare($current_version, BU_SLIDESHOW_VERSION ) ) {
+	if ( $run_all || -1 === version_compare($current_version, BU_SLIDESHOW_VERSION ) ) {
 
-		if( -1 === version_compare($current_version, '2.3' ) ){
+		if( $run_all || -1 === version_compare($current_version, '2.3' ) ){
 			bu_slideshow_migrate_shows();
 		}
 
@@ -31,6 +31,7 @@ function bu_slideshow_upgrade() {
 function bu_slideshow_migrate_shows() {
 	$all_slideshows = get_option( 'bu_slideshows' , array() );
 	$has_errors = FALSE;
+	$slideshow_id_map_option = 'bu_slideshow_id_map';
 
 	foreach ($all_slideshows as $k => $show) {
 
@@ -56,11 +57,28 @@ function bu_slideshow_migrate_shows() {
 				__FUNCTION__, $result->get_error_message(), var_export( $show, TRUE ) ) );
 		    $has_errors = TRUE;
 		} else {
-			add_post_meta( $postID, '_bu_slideshow', $show, true );
+			if( false === add_post_meta( $postID, '_bu_slideshow', $show, true ) ){
+				error_log( sprintf( '[%s] Error adding posst meta: ID %d Object: %s',
+					__FUNCTION__, $postID, var_export( $show, TRUE ) ) );
+				$has_errors = TRUE;
+			}
 		}
 
-		// if( ! $has_errors ){
-		// 	delete_option( 'bu_slideshows' );
-		// }
+		if( !$has_errors ){
+			$map = get_option( $slideshow_id_map_option );
+
+			if( FALSE === $map ){
+				$map = array();
+				add_option( $slideshow_id_map_option, $map, '', false );
+			}
+			
+			$map[ $show->id ] = $postID;
+			
+			update_option( $slideshow_id_map_option, $map );
+		}
 	}
+
+	// if( ! $has_errors ){
+	// 	delete_option( 'bu_slideshows' );
+	// }
 }

--- a/slideshow-upgrade.php
+++ b/slideshow-upgrade.php
@@ -1,0 +1,66 @@
+<?php
+
+add_action('init', 'bu_slideshow_upgrade', 99);
+
+/**
+ * Run any appropriate upgrade routines for the current version &
+ * update version number in site options
+ */
+function bu_slideshow_upgrade() {
+	$current_version = get_option('bu_slideshow_version');
+
+	if ( ( empty($current_version) && version_compare('2.3', BU_SLIDESHOW_VERSION, '<=') ) 
+		|| -1 === version_compare($current_version, BU_SLIDESHOW_VERSION ) ) {
+
+		if( -1 === version_compare($current_version, '2.3' ) ){
+			bu_slideshow_migrate_shows();
+		}
+
+		update_option('bu_slideshow_version', BU_SLIDESHOW_VERSION);
+	}
+// 	$all_slideshows = get_option( 'bu_slideshows' , array() );
+	
+// 	foreach ($all_slideshows as $k => $show) {
+// print_r(serialize($show)."\n\n\n");
+// 	}
+}
+
+/**
+ *  Move slideshows to individual site options
+ */
+function bu_slideshow_migrate_shows() {
+	$all_slideshows = get_option( 'bu_slideshows' , array() );
+	$has_errors = FALSE;
+
+	foreach ($all_slideshows as $k => $show) {
+
+		if( ! intval( $show->id ) ){
+			$has_errors = TRUE;
+			error_log( sprintf( '[%s] Invalid Slideshow ID: %d Object: %s',
+				__FUNCTION__, $show->id, var_export( $show, TRUE ) ) );
+			continue;
+		}
+
+		// Create post object
+		$slideshow = array(
+			'post_title'	=> $show->name,
+			'post_content'	=> '',
+			'post_status'	=> 'publish',
+			'post_type'		=> 'bu_slideshow',
+		);
+
+		$result = $postID = wp_insert_post( $slideshow );
+
+		if( is_wp_error( $result ) ) {
+		    error_log( sprintf( '[%s] Error creating post: %s Object: %s',
+				__FUNCTION__, $result->get_error_message(), var_export( $show, TRUE ) ) );
+		    $has_errors = TRUE;
+		} else {
+			add_post_meta( $postID, '_bu_slideshow', $show, true );
+		}
+
+		// if( ! $has_errors ){
+		// 	delete_option( 'bu_slideshows' );
+		// }
+	}
+}


### PR DESCRIPTION
Also establishes option `bu_slideshow_id_map` for routing references to old slideshows (e.g. `[bu_slideshow show_id="1"]`

### Todo:
- [ ] Uncomment [delete_option('bu_slideshows')](https://github.com/bu-ist/bu-slideshow/blob/feature/custom-post-type/slideshow-upgrade.php#L81-L83) after testing