### PR TITLE
Optimize admin query for slideshows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+sudo: false
+dist: trusty
+
 language: php
 
 notifications:
@@ -7,26 +10,50 @@ notifications:
 
 branches:
   only:
-    - master
+  - /.*/
 
-sudo: false
+cache:
+  directories:
+    - vendor
+    - $HOME/.composer/cache
 
-php:
-  - 7.1
+matrix:
+  include:
+    - php: 7.2
+      env: WP_VERSION=latest
+    - php: 7.2
+      env: WP_VERSION=4.9.10
+    - php: 7.0
+      env: WP_VERSION=latest
+    - php: 7.0
+      env: WP_VERSION=4.9.10
 
-env:
-  - WP_VERSION=4.9.10 WP_MULTISITE=0
-  - WP_VERSION=4.9.10 WP_MULTISITE=1
-  
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
   - |
-    if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then
-      composer global require "phpunit/phpunit=5.7.*"
+    if [ -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini ]; then
+      phpenv config-rm xdebug.ini
     else
-      composer global require "phpunit/phpunit=4.8.*"
+      echo "xdebug.ini does not exist"
+    fi
+  - |
+    if [[ ! -z "$WP_VERSION" ]] ; then
+      bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
+      composer global require "phpunit/phpunit=4.8.*|5.7.*"
+    fi
+  - |
+    if [[ "$WP_TRAVISCI" == "phpcs" ]] ; then
+      composer global require wp-coding-standards/wpcs
+      phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
     fi
 
-  - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
-
-script: phpunit
+script:
+  - |
+    if [[ ! -z "$WP_VERSION" ]] ; then
+      phpunit
+      WP_MULTISITE=1 phpunit
+    fi
+  - |
+    if [[ "$WP_TRAVISCI" == "phpcs" ]] ; then
+      phpcs
+    fi

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [ $# -lt 3 ]; then
-	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version]"
+	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version] [skip-database-creation]"
 	exit 1
 fi
 
@@ -10,9 +10,12 @@ DB_USER=$2
 DB_PASS=$3
 DB_HOST=${4-localhost}
 WP_VERSION=${5-latest}
+SKIP_DB_CREATE=${6-false}
 
-WP_TESTS_DIR=${WP_TESTS_DIR-/tmp/wordpress-tests-lib}
-WP_CORE_DIR=${WP_CORE_DIR-/tmp/wordpress/}
+TMPDIR=${TMPDIR-/tmp}
+TMPDIR=$(echo $TMPDIR | sed -e "s/\/$//")
+WP_TESTS_DIR=${WP_TESTS_DIR-$TMPDIR/wordpress-tests-lib}
+WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress/}
 
 download() {
     if [ `which curl` ]; then
@@ -22,8 +25,17 @@ download() {
     fi
 }
 
-if [[ $WP_VERSION =~ [0-9]+\.[0-9]+(\.[0-9]+)? ]]; then
-	WP_TESTS_TAG="tags/$WP_VERSION"
+if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+$ ]]; then
+	WP_TESTS_TAG="branches/$WP_VERSION"
+elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
+	if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
+		# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
+		WP_TESTS_TAG="tags/${WP_VERSION%??}"
+	else
+		WP_TESTS_TAG="tags/$WP_VERSION"
+	fi
+elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+	WP_TESTS_TAG="trunk"
 else
 	# http serves a single offer, whereas https serves multiple. we only want one
 	download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
@@ -46,14 +58,36 @@ install_wp() {
 
 	mkdir -p $WP_CORE_DIR
 
-	if [ $WP_VERSION == 'latest' ]; then
-		local ARCHIVE_NAME='latest'
+	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+		mkdir -p $TMPDIR/wordpress-nightly
+		download https://wordpress.org/nightly-builds/wordpress-latest.zip  $TMPDIR/wordpress-nightly/wordpress-nightly.zip
+		unzip -q $TMPDIR/wordpress-nightly/wordpress-nightly.zip -d $TMPDIR/wordpress-nightly/
+		mv $TMPDIR/wordpress-nightly/wordpress/* $WP_CORE_DIR
 	else
-		local ARCHIVE_NAME="wordpress-$WP_VERSION"
+		if [ $WP_VERSION == 'latest' ]; then
+			local ARCHIVE_NAME='latest'
+		elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+ ]]; then
+			# https serves multiple offers, whereas http serves single.
+			download https://api.wordpress.org/core/version-check/1.7/ $TMPDIR/wp-latest.json
+			if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
+				# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
+				LATEST_VERSION=${WP_VERSION%??}
+			else
+				# otherwise, scan the releases and get the most up to date minor version of the major release
+				local VERSION_ESCAPED=`echo $WP_VERSION | sed 's/\./\\\\./g'`
+				LATEST_VERSION=$(grep -o '"version":"'$VERSION_ESCAPED'[^"]*' $TMPDIR/wp-latest.json | sed 's/"version":"//' | head -1)
+			fi
+			if [[ -z "$LATEST_VERSION" ]]; then
+				local ARCHIVE_NAME="wordpress-$WP_VERSION"
+			else
+				local ARCHIVE_NAME="wordpress-$LATEST_VERSION"
+			fi
+		else
+			local ARCHIVE_NAME="wordpress-$WP_VERSION"
+		fi
+		download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  $TMPDIR/wordpress.tar.gz
+		tar --strip-components=1 -zxmf $TMPDIR/wordpress.tar.gz -C $WP_CORE_DIR
 	fi
-
-	download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  /tmp/wordpress.tar.gz
-	tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
 
 	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
 }
@@ -71,13 +105,14 @@ install_test_suite() {
 		# set up testing suite
 		mkdir -p $WP_TESTS_DIR
 		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
 	fi
-
-	cd $WP_TESTS_DIR
 
 	if [ ! -f wp-tests-config.php ]; then
 		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
-		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR':" "$WP_TESTS_DIR"/wp-tests-config.php
+		# remove all forward slashes in the end
+		WP_CORE_DIR=$(echo $WP_CORE_DIR | sed "s:/\+$::")
+		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
@@ -87,6 +122,11 @@ install_test_suite() {
 }
 
 install_db() {
+
+	if [ ${SKIP_DB_CREATE} = "true" ]; then
+		return 0
+	fi
+
 	# parse DB_HOST for port or socket references
 	local PARTS=(${DB_HOST//\:/ })
 	local DB_HOSTNAME=${PARTS[0]};

--- a/bu-slideshow.php
+++ b/bu-slideshow.php
@@ -1088,6 +1088,12 @@ class BU_Slideshow {
 		$allowed_screens = apply_filters( 'bu_slideshow_insert_slideshow_screens', self::$editor_screens );
 		$screen_id       = $current_screen->id;
 
+		// If the current screen is using the block editor,
+		// we don't need to output the button and modal.
+		if ( bu_slideshow_is_block_editor() ) {
+			return false;
+		}
+
 		if ( $screen_id && post_type_supports( $screen_id, self::$post_support_slug ) ) {
 			return true;
 		}
@@ -1103,20 +1109,17 @@ class BU_Slideshow {
 	 * Adds modal UI to footer, for display in thickbox.
 	 */
 	static public function admin_footer() {
-		
-			if (self::using_editor()):   ?>
-				<div id="bu_slideshow_modal_wrap" class="wrap postbox">
+		if ( self::using_editor() ) :
+		?>
+			<div id="bu_slideshow_modal_wrap" class="wrap postbox">
+				<h2><?php _e('Insert Slideshow', BU_SSHOW_LOCAL); ?></h2>
+				<?php echo self::get_selector(); ?>
+				<p><a href="#" id="bu_insert_slideshow" class="button-primary"><?php _e('Insert Slideshow', BU_SSHOW_LOCAL); ?></a></p>
+			</div>
 
-					<h2><?php _e('Insert Slideshow', BU_SSHOW_LOCAL); ?></h2>
-					<?php echo self::get_selector(); ?>
-					<p><a href="#" id="bu_insert_slideshow" class="button-primary"><?php _e('Insert Slideshow', BU_SSHOW_LOCAL); ?></a></p>
-				</div>
-
-			<?php
-			endif;
-		
+		<?php
+		endif;
 	}
-
 
 	/**
 	 * Adds 'Insert Slideshow' button above editor
@@ -1125,52 +1128,63 @@ class BU_Slideshow {
 	 * @return string
 	 */
 	static public function add_media_button() {
-
-		if (self::using_editor()) {
-			$html = sprintf('<a class="button" id="bu_slideshow_modal_button" title="%s" href="#">%s</a>', __('Add Slideshow', BU_SSHOW_LOCAL), __('Add Slideshow', BU_SSHOW_LOCAL));
-
-			echo $html;
+		if ( self::using_editor() ) {
+			echo sprintf( '<a class="button" id="bu_slideshow_modal_button" title="%s" href="#">%s</a>', __( 'Add Slideshow', BU_SSHOW_LOCAL ), __( 'Add Slideshow', BU_SSHOW_LOCAL ) );
 		}
-
 	}
 
 }
 
 BU_Slideshow::add_plugins_loaded_hook();
 
+/**
+ * Determine whether the block editor is loading on the current screen.
+ *
+ * Checks if `get_current_screen()->is_block_editor()` exists (WP 5.x).
+ * Falls back to `is_gutenberg_page` if it exists.
+ *
+ * @return bool
+ */
+function bu_slideshow_is_block_editor() {
+	if ( method_exists( get_current_screen(), 'is_block_editor' ) ) {
+		return get_current_screen()->is_block_editor();
+	} elseif ( function_exists( 'is_gutenberg_page' ) ) {
+		return is_gutenberg_page();
+	}
 
-function bu_slideshow_meta_box()
-{
-    
-	    $screens = ['post', 'page'];
-	    foreach ($screens as $screen) {
-	        add_meta_box(
-	            'bu_slideshow_box_id',           // Unique ID
-	            'SlideShow Meta Box',  // Box title
-	            'bu_slideshow_meta_box_html',  // Content callback, must be of type callable
-	            $screen                   // Post type
-	        );
-	    }
-	
+	return false;
 }
-add_action('add_meta_boxes', 'bu_slideshow_meta_box');
-function bu_slideshow_meta_box_html($post)
-{
-   $html = BU_Slideshow::shortcode_handler($args);
-   echo '<div id="bu_slideshow_metabox_wrap" class="wrap postbox">';
-	
-		$button_label = 'Generate Slideshow Shortcode';
-	//add js to hide modal
-		echo '<script type="text/javascript">
-		</script>';
-				echo "<h2>";
-				_e($button_label, BU_SSHOW_LOCAL);
-				echo "</h2>";
-				echo BU_Slideshow::get_selector();
-				echo '<p><a href="#" id="bu_insert_slideshow" class="button-primary">';
-				_e($button_label, BU_SSHOW_LOCAL);
-				echo "</a></p>
-			</div>";
+
+/**
+ * Add a metabox to block editor pages for compatibility.
+ */
+function bu_slideshow_meta_box() {
+	// If the current screen is not using the block editor,
+	// we don't need to add this metabox.
+	if ( ! bu_slideshow_is_block_editor() ) {
+		return;
+	}
+
+	add_meta_box(
+		'bu_slideshow_box_id',        // Unique ID
+		'SlideShow Meta Box',         // Box title
+		'bu_slideshow_meta_box_html', // Content callback, must be of type callable
+		array( 'post', 'page' )       // Post types
+	);
+}
+add_action( 'add_meta_boxes', 'bu_slideshow_meta_box' );
+
+function bu_slideshow_meta_box_html( $post ) {
+	$button_label = 'Generate Slideshow Shortcode';
+	?>
+	<div id="bu_slideshow_metabox_wrap" class="wrap postbox">
+		<h2><?php _e( $button_label, BU_SSHOW_LOCAL ); ?></h2>
+		<?php echo BU_Slideshow::get_selector(); ?>
+		<p>
+			<a href="#" id="bu_insert_slideshow" class="button-primary"><?php _e( $button_label, BU_SSHOW_LOCAL ); ?></a>
+		</p>
+	</div>
+	<?php
 }
 
 /**

--- a/bu-slideshow.php
+++ b/bu-slideshow.php
@@ -93,7 +93,8 @@ class BU_Slideshow {
 		add_action('admin_enqueue_scripts', array(__CLASS__, 'admin_scripts_styles'));
 		add_action('wp_enqueue_scripts', array(__CLASS__, 'public_scripts_styles'));
 		add_action('media_buttons', array(__CLASS__, 'add_media_button'),99);
-		add_action('admin_footer', array(__CLASS__, 'admin_footer'));
+		add_action('admin_footer-post.php', array(__CLASS__, 'admin_footer'));
+		add_action('admin_footer-post-new.php', array(__CLASS__, 'admin_footer'));
 
 		// media upload/insert restrictions
 		if ('media-upload.php' === $pagenow || 'async-upload.php' === $pagenow) {
@@ -1083,17 +1084,11 @@ class BU_Slideshow {
 	 * @return boolean
 	 */
 	static public function using_editor() {
+		$current_screen  = get_current_screen();
+		$allowed_screens = apply_filters( 'bu_slideshow_insert_slideshow_screens', self::$editor_screens );
+		$screen_id       = $current_screen->id;
 
-		global $current_screen;
-
-		if (!$current_screen || !$current_screen->id) {
-			return false;
-		}
-
-		$allowed_screens = apply_filters('bu_slideshow_insert_slideshow_screens', self::$editor_screens);
-		$screen_id = $current_screen->id;
-
-		if ($screen_id && post_type_supports($screen_id, self::$post_support_slug)) {
+		if ( $screen_id && post_type_supports( $screen_id, self::$post_support_slug ) ) {
 			return true;
 		}
 

--- a/bu-slideshow.php
+++ b/bu-slideshow.php
@@ -802,16 +802,22 @@ class BU_Slideshow {
 	 */
 	static public function get_slideshows() {
 		$slideshows = array();
-		$slideshow_posts = get_posts( array(
-			'post_type' => 'bu_slideshow',
-			'posts_per_page' => -1,
-			'orderby' => 'title',
-			'order' => 'asc'
+
+		$slideshow_ids = get_posts(
+			array(
+				'post_type'              => 'bu_slideshow',
+				'posts_per_page'         => 500,
+				'orderby'                => 'title',
+				'order'                  => 'asc',
+				'no_found_rows'          => true,
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
+				'fields'                 => 'ids',
 			)
 		);
 
-		foreach ($slideshow_posts as $show) {
-			$slideshows[ $show->ID ] = self::get_slideshow( $show->ID );
+		foreach ( $slideshow_ids as $id ) {
+			$slideshows[ $id ] = self::get_slideshow( $id );
 		}
 
 		return $slideshows;


### PR DESCRIPTION
https://trello.com/c/eL89BiQj/23-ca-10-bu-slideshow

This sets `posts_per_page` to 500 (which may or may not be sufficient) to avoid an unbounded query and adds other arguments to help optimize things.

It also uses more specific hooks to add the modal to the admin footer only when it's needed, and further checks that the page is not a block editor page before outputting the modal and the `Add Slideshow` button. Likewise, it checks that the page _is_ a block editor page before adding the newer metabox interface.

Lastly, adds some minor syntax adjustments and attempts to tighten things up a bit.